### PR TITLE
Fix: add write permissions for mkdocs

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -14,6 +14,8 @@ jobs:
   docs:
     name: Publish docs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Needs `write` permission to push the `gh-pages` branch. See failure here: https://github.com/compilerla/pems/actions/runs/12168357388/job/33938992891

I made the default permissions for GitHub Actions in this repo be `read`.