### PR TITLE
Fix: ignore .egg-info

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 .git/
+*.egg-info


### PR DESCRIPTION
Otherwise any existing directory is copied with the Docker build, which then fails on `pip install -e .[dev]`.