### PR TITLE
CI: create release workflow

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,9 +8,6 @@ DJANGO_DB_RESET=true
 DJANGO_STORAGE_DIR=.
 DJANGO_DB_FILE=django.db
 
-# Other Django config
-DJANGO_DEBUG=true
-
 # uncomment to start the elasticstack services with compose
 # COMPOSE_PROFILES=elasticstack
 

--- a/.github/lighthouserc.json
+++ b/.github/lighthouserc.json
@@ -1,0 +1,14 @@
+{
+  "ci": {
+    "numberOfRuns": 3,
+    "settings": {
+      "preset": "desktop"
+    },
+    "assert": {
+      "assertions": {
+        "categories:accessibility": ["error", { "minScore": 1 }],
+        "categories:best-practices": ["warn", { "minScore": 0.9 }]
+      }
+    }
+  }
+}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,104 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    tags:
+      # pre-release tag
+      - "202[4-9].[0-9][0-9].[0-9]+-rc[0-9]+"
+      # release tags
+      - "202[4-9].[0-9][0-9].[0-9]+"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests-ui:
+    uses: ./.github/workflows/tests-ui.yml
+    if: github.ref_type == 'tag'
+
+  tests-pytest:
+    uses: ./.github/workflows/tests-pytest.yml
+    if: github.ref_type == 'tag'
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [tests-ui, tests-pytest]
+    if: (!cancelled())
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .github/workflows/.python-version
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Write python packages to file
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install pipdeptree
+          pip install -e .
+          pipdeptree
+          pipdeptree >> pems/static/requirements.txt
+
+      - name: Write commit SHA to file
+        run: echo "${{ github.sha }}" >> pems/static/sha.txt
+
+      - name: Write tag to file
+        run: echo "${{ github.ref_name }}" >> pems/static/version.txt
+
+      - name: Docker Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build, tag, and push image to GitHub Container Registry
+        uses: docker/build-push-action@v6
+        with:
+          platforms: linux/amd64,linux/arm64
+          builder: ${{ steps.buildx.outputs.name }}
+          build-args: GIT-SHA=${{ github.sha }}
+          cache-from: type=gha,scope=compilerla
+          cache-to: type=gha,scope=compilerla,mode=max
+          context: .
+          file: appcontainer/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+            ghcr.io/${{ github.repository }}:${{ github.sha }}
+
+  release:
+    needs: deploy
+    if: ${{ github.ref_type == 'tag' && !contains(github.ref, '-rc') }}
+    runs-on: ubuntu-latest
+    permissions:
+      # https://github.com/softprops/action-gh-release#permissions
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          prerelease: false
+          generate_release_notes: true

--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -1,0 +1,31 @@
+name: UI & a11y tests
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  tests-ui:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Start app
+        run: |
+          cp .env.sample .env
+          docker compose up --detach app
+
+      - name: Run Lighthouse tests for a11y
+        uses: treosh/lighthouse-ci-action@12.1.0
+        with:
+          urls: http://localhost:8000/admin
+          configPath: ".github/lighthouserc.json"
+          temporaryPublicStorage: true
+          uploadArtifacts: true

--- a/compose.yml
+++ b/compose.yml
@@ -8,7 +8,7 @@ services:
     image: caltrans/pems:app
     env_file: .env
     ports:
-      - "8000"
+      - "${DJANGO_LOCAL_PORT:-8000}:8000"
 
   dev:
     build:


### PR DESCRIPTION
Closes #11

This release workflow is triggered by pushing a calver formatted tag. The workflow:

- runs tests, builds the app container image, and pushes to GHCR
- for a release tag, it makes a GitHub release
