### PR TITLE
CI: tests run for all pushes to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,11 +18,9 @@ defaults:
 jobs:
   tests-ui:
     uses: ./.github/workflows/tests-ui.yml
-    if: github.ref_type == 'tag'
 
   tests-pytest:
     uses: ./.github/workflows/tests-pytest.yml
-    if: github.ref_type == 'tag'
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
Removed the `if: github.ref_type == 'tag'` condition on `tests-ui` and `tests-pytest` in the `Deploy` workflow so that the tests run on all pushes (both commits and tags) to `main`.