### PR TITLE
Docs: add product roadmap

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,11 +5,13 @@ Caltrans Performance Measurement System
 PeMS is open-source software that is designed, developed, and maintained by [Compiler LLC](https://compiler.la) on behalf of Caltrans Traffic Operations.
 
 ## Current Work
+
 We do sprint planning and track day-to-day work in our [Project Board](https://github.com/orgs/compilerla/projects/3/views/1).
 
 See our current [Milestones](https://github.com/compilerla/pems/milestones) for a higher level view of project progress.
 
 ## Product Roadmap
+
 Our product roadmap captures what we're currently building, what we've built, and what we plan to build in future quarters. It is updated on a regular basis, aligned with project progress.
 
 ```mermaid

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,3 +3,61 @@
 Caltrans Performance Measurement System
 
 PeMS is open-source software that is designed, developed, and maintained by [Compiler LLC](https://compiler.la) on behalf of Caltrans Traffic Operations.
+
+## Current Work
+We do sprint planning and track day-to-day work in our [Project Board](https://github.com/orgs/compilerla/projects/3/views/1).
+
+See our current [Milestones](https://github.com/compilerla/pems/milestones) for a higher level view of project progress.
+
+## Product Roadmap
+Our product roadmap captures what we're currently building, what we've built, and what we plan to build in future quarters. It is updated on a regular basis, aligned with project progress.
+
+```mermaid
+timeline
+    title PeMS Product Roadmap
+%% PeMS Epics (2024)
+          section 2024
+
+          Q3<br>Complete
+          : Project launch
+          : Established resources and overall scope
+          : Began discovery work
+
+          Q4<br>Now
+          : Confirm site architecture
+          : Create local environment
+          : Set up GitHub repository
+          : Scaffold app structure
+          : Create a prioritized backlog of features
+
+%% PeMS Epics (2025)
+          section 2025
+
+          Q1<br>Planned
+          : Create dev environment
+          : Create test environment
+          : Set up a working CI/CD pipeline
+          : Launch test version of site for Caltrans users
+
+          Q2<br>Planned
+          : Create production environment
+
+          Q3<br>Future
+          : Compiler contract ends July 2025
+
+%%{
+    init: {
+        'logLevel': 'debug',
+        'theme': 'default' ,
+        'themeVariables': {
+            'cScale0': '#ffa500', 'cScaleLabel0': '#000000',
+            'cScale1': '#ffff00', 'cScaleLabel1': '#000000',
+            'cScale2': '#ffff00', 'cScaleLabel2': '#000000',
+            'cScale3': '#008000', 'cScaleLabel3': '#ffffff',
+            'cScale4': '#0000ff', 'cScaleLabel4': '#ffffff',
+            'cScale5': '#4b0082', 'cScaleLabel5': '#ffffff',
+            'cScale6': '#000000', 'cScaleLabel6': '#ffffff'
+        }
+    }
+}%%
+```


### PR DESCRIPTION
Updated the main doc site page with product roadmap and some of the language Andy uses for Benefits (links to our sprint and milestones in the GitHub project). 

Had some trouble with the formatting on the Mermaid diagram (see Q4 of 2024 - for some reason the arrow disappeared and I can't get it back - maybe just too many boxes for the frame?). Not a huge deal, but if there's an easy fix I would welcome it!

Also - should this be its own page? Not sure yet how to build out separate markdown files as pages on a doc site, so I just updated the existing file.