### PR TITLE
CI: deploy job runs only if tests pass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,7 +28,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [tests-ui, tests-pytest]
-    if: (!cancelled())
     permissions:
       packages: write
 


### PR DESCRIPTION
Removed the `if` condition on the `deploy` job so that deploy does not run regardless of the success or failure of `tests-ui` and `tests-pytest`, i.e., `needs` actually behaves as expected. Referred to the [warning note in the docs](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#always).