### PR TITLE
Fix: Docs site theme and Roadmap style

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,13 +52,10 @@ timeline
         'logLevel': 'debug',
         'theme': 'default' ,
         'themeVariables': {
-            'cScale0': '#ffa500', 'cScaleLabel0': '#000000',
-            'cScale1': '#ffff00', 'cScaleLabel1': '#000000',
-            'cScale2': '#ffff00', 'cScaleLabel2': '#000000',
-            'cScale3': '#008000', 'cScaleLabel3': '#ffffff',
-            'cScale4': '#0000ff', 'cScaleLabel4': '#ffffff',
-            'cScale5': '#4b0082', 'cScaleLabel5': '#ffffff',
-            'cScale6': '#000000', 'cScaleLabel6': '#ffffff'
+            'cScale0': 'orange',
+            'cScaleLabel0': 'black',
+            'cScale1': 'yellow',
+            'cScaleLabel1': 'black'
         }
     }
 }%%

--- a/docs/styles/theme.css
+++ b/docs/styles/theme.css
@@ -1,0 +1,5 @@
+[data-md-color-scheme="default"] {
+  --md-primary-fg-color: #045b86;
+  --md-accent-fg-color: #044869;
+  --md-mermaid-label-fg-color: #000000;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,20 +10,7 @@ theme:
     - navigation.tabs
     - toc.integrate
   palette:
-    - media: "(prefers-color-scheme: light)"
-      scheme: default
-      primary: blue
-      accent: green
-      toggle:
-        icon: material/toggle-switch-off-outline
-        name: Switch to dark mode
-    - media: "(prefers-color-scheme: dark)"
-      scheme: slate
-      primary: blue
-      accent: green
-      toggle:
-        icon: material/toggle-switch
-        name: Switch to light mode
+    scheme: default
 
 extra:
   analytics:
@@ -38,6 +25,7 @@ plugins:
 
 extra_css:
   - https://use.fontawesome.com/releases/v6.1.2/css/all.css
+  - styles/theme.css
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
- Disables dark mode
- Updates primary/accent color for contrast and accessibility
- Fixes colors on roadmap