### PR TITLE
Fix: `_discover_apps` test

### DIFF
--- a/tests/pytest/streamlit_app/test_utils.py
+++ b/tests/pytest/streamlit_app/test_utils.py
@@ -44,7 +44,7 @@ def test_default_app_page():
 def test__discover_apps(app_paths):
     discovered = utils._discover_apps()
 
-    assert discovered == app_paths
+    assert set(discovered) == set(app_paths)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #92

The discovered apps are now compared set-wise instead of ordered-wise. This is to ensure that the order of the apps does not matter and fixes a failing assertion that was seen locally but not in the CI.
