### PR TITLE
Feat: URL setup for `districts` app

### DIFF
--- a/pems/districts/templates/districts/district.html
+++ b/pems/districts/templates/districts/district.html
@@ -1,0 +1,2 @@
+<h1>District {{ district }}</h1>
+<p> URL of route: {% url "districts:district" district%} </p>

--- a/pems/districts/templates/districts/index.html
+++ b/pems/districts/templates/districts/index.html
@@ -1,0 +1,1 @@
+<h1>Districts</h1>

--- a/pems/districts/urls.py
+++ b/pems/districts/urls.py
@@ -2,7 +2,13 @@
 URLConf for the districts app.
 """
 
+from django.urls import path
+
+from pems.districts import views
+
 app_name = "districts"
 urlpatterns = [
     # /districts
+    path("", views.IndexView.as_view(), name="index"),
+    path("<int:district>", views.DistrictView.as_view(), name="district"),
 ]

--- a/pems/districts/views.py
+++ b/pems/districts/views.py
@@ -1,1 +1,15 @@
-# Create your views here.
+from django.views.generic import TemplateView
+
+
+class IndexView(TemplateView):
+    template_name = "districts/index.html"
+
+
+class DistrictView(TemplateView):
+    template_name = "districts/district.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        district = self.kwargs.get("district")
+        context["district"] = district
+        return context

--- a/pems/urls.py
+++ b/pems/urls.py
@@ -1,24 +1,8 @@
-"""
-URL configuration for pems project.
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/5.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
-
 from django.contrib import admin
 from django.urls import include, path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
+    path("districts/", include("pems.districts.urls")),
     path("streamlit/", include("pems.streamlit_sample.urls")),
 ]

--- a/tests/pytest/conftest.py
+++ b/tests/pytest/conftest.py
@@ -1,5 +1,17 @@
+import pytest
 from pytest_socket import disable_socket
 
 
 def pytest_runtest_setup():
     disable_socket()
+
+
+@pytest.fixture
+def app_request(rf):
+    """
+    Fixture creates and initializes a new Django request object similar to a real application request.
+    """
+    # create a request for the path, initialize
+    app_request = rf.get("/some/arbitrary/path")
+
+    return app_request

--- a/tests/pytest/pems/districts/test_views.py
+++ b/tests/pytest/pems/districts/test_views.py
@@ -1,0 +1,21 @@
+import pytest
+
+from pems.districts import views
+
+
+class TestDistrictView:
+    @pytest.fixture
+    def view(app_request):
+        v = views.DistrictView()
+        v.setup(app_request, district=1)
+
+        return v
+
+    def test_get_context_data(self, view):
+
+        context = view.get_context_data()
+
+        assert context["district"] == 1
+
+    def test_template_name(self, view):
+        assert view.template_name == "districts/district.html"


### PR DESCRIPTION
Closes #67 

This PR does the initial setup of the `urlpatterns`. It also adds ~a `routes.py` module to manage the names of the `urlpatterns`, a context processor for the module, and~ a simple template for the Caltrans Districts page and for the landing page of a Caltrans District.
