### PR TITLE
Feat: UI templates for the `districts` application

### DIFF
--- a/pems/districts/templates/districts/district.html
+++ b/pems/districts/templates/districts/district.html
@@ -4,7 +4,7 @@
     District {{ district_number }} - {{ district.name }}
 {% endblock headline %}
 
-{% block district-content %}
+{% block districts-content %}
     <div class="row">
         <div class="col-lg-4 border">
             <h2>Form</h2>
@@ -21,4 +21,4 @@
             <h2>Map</h2>
         </div>
     </div>
-{% endblock district-content %}
+{% endblock districts-content %}

--- a/pems/districts/templates/districts/district.html
+++ b/pems/districts/templates/districts/district.html
@@ -1,7 +1,7 @@
 {% extends "districts/index.html" %}
 
 {% block headline %}
-    District {{ url_district }} - {{ district_query.name }}
+    District {{ district_number }} - {{ district.name }}
 {% endblock headline %}
 
 {% block district-content %}
@@ -15,7 +15,7 @@
     </div>
     <div class="row">
         <div class="col-lg-4 border">
-            <h2>Details for {{ district_query.name }}</h2>
+            <h2>Details for {{ district.name }}</h2>
         </div>
         <div class="col-lg-8 border">
             <h2>Map</h2>

--- a/pems/districts/templates/districts/district.html
+++ b/pems/districts/templates/districts/district.html
@@ -1,2 +1,24 @@
-<h1>District {{ district }}</h1>
-<p>URL of route: {% url "districts:district" district %}</p>
+{% extends "districts/index.html" %}
+
+{% block headline %}
+    District {{ url_district }} - {{ district_query.name }}
+{% endblock headline %}
+
+{% block district-content %}
+    <div class="row">
+        <div class="col-lg-4 border">
+            <h2>Form</h2>
+        </div>
+        <div class="col-lg-8 border">
+            <h2>Chart</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-lg-4 border">
+            <h2>Details for {{ district_query.name }}</h2>
+        </div>
+        <div class="col-lg-8 border">
+            <h2>Map</h2>
+        </div>
+    </div>
+{% endblock district-content %}

--- a/pems/districts/templates/districts/district.html
+++ b/pems/districts/templates/districts/district.html
@@ -1,7 +1,7 @@
 {% extends "districts/index.html" %}
 
 {% block headline %}
-    District {{ district_number }} - {{ district.name }}
+    District {{ district.number }} - {{ district.name }}
 {% endblock headline %}
 
 {% block districts-content %}

--- a/pems/districts/templates/districts/district.html
+++ b/pems/districts/templates/districts/district.html
@@ -1,7 +1,7 @@
 {% extends "districts/index.html" %}
 
 {% block headline %}
-    District {{ district.number }} - {{ district.name }}
+    District {{ current_district.number }} - {{ current_district.name }}
 {% endblock headline %}
 
 {% block districts-content %}
@@ -15,7 +15,7 @@
     </div>
     <div class="row">
         <div class="col-lg-4 border">
-            <h2>Details for {{ district.name }}</h2>
+            <h2>Details for {{ current_district.name }}</h2>
         </div>
         <div class="col-lg-8 border">
             <h2>Map</h2>

--- a/pems/districts/templates/districts/index.html
+++ b/pems/districts/templates/districts/index.html
@@ -21,7 +21,7 @@
             </div>
             <div class="col-lg-10 pb-lg-5">
 
-                {% block district-content %}
+                {% block districts-content %}
                     <div class="row">
                         <div class="col-lg-4 border">
                             <h2>Form</h2>
@@ -38,7 +38,7 @@
                             <h2>Map</h2>
                         </div>
                     </div>
-                {% endblock district-content %}
+                {% endblock districts-content %}
 
             </div>
         </div>

--- a/pems/districts/templates/districts/index.html
+++ b/pems/districts/templates/districts/index.html
@@ -11,7 +11,7 @@
                 <!-- Side navigation -->
                 <nav aria-labelledby="navigation-list" class="side-navigation">
                     <ul class="list-navigation">
-                        {% for district in district_queryset %}
+                        {% for district in districts.all %}
                             <li>
                                 <a href="{% url 'districts:district' district.number %}">District {{ district.number }}</a>
                             </li>

--- a/pems/districts/templates/districts/index.html
+++ b/pems/districts/templates/districts/index.html
@@ -1,7 +1,46 @@
 {% extends "core/base.html" %}
+
 {% block headline %}
     Districts
 {% endblock headline %}
+
 {% block inner-content %}
-    <p>Districts</p>
+    <div class="container p-t-lg">
+        <div class="row">
+            <div class="col-lg-2 pb-lg-5" role="complementary">
+                <!-- Side navigation -->
+                <nav aria-labelledby="navigation-list" class="side-navigation">
+                    <ul class="list-navigation">
+                        {% for district in district_queryset %}
+                            <li>
+                                <a href="{% url 'districts:district' district.number %}">District {{ district.number }}</a>
+                            </li>
+                        {% endfor %}
+                    </ul>
+                </nav>
+            </div>
+            <div class="col-lg-10 pb-lg-5">
+
+                {% block district-content %}
+                    <div class="row">
+                        <div class="col-lg-4 border">
+                            <h2>Form</h2>
+                        </div>
+                        <div class="col-lg-8 border">
+                            <h2>Chart</h2>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-4 border">
+                            <h2>Details</h2>
+                        </div>
+                        <div class="col-lg-8 border">
+                            <h2>Map</h2>
+                        </div>
+                    </div>
+                {% endblock district-content %}
+
+            </div>
+        </div>
+    </div>
 {% endblock inner-content %}

--- a/pems/districts/urls.py
+++ b/pems/districts/urls.py
@@ -10,5 +10,5 @@ app_name = "districts"
 urlpatterns = [
     # /districts
     path("", views.IndexView.as_view(), name="index"),
-    path("<int:district>", views.DistrictView.as_view(), name="district"),
+    path("<int:district_number>", views.DistrictView.as_view(), name="district"),
 ]

--- a/pems/districts/views.py
+++ b/pems/districts/views.py
@@ -19,8 +19,8 @@ class IndexView(DistrictContextMixin, TemplateView):
 
 class DistrictView(DistrictContextMixin, DetailView):
     model = District
-    context_object_name = "district"
+    context_object_name = "current_district"
     template_name = "districts/district.html"
 
     def get_object(self):
-        return District.objects.get(number__iexact=self.kwargs["district"])
+        return District.objects.get(number__iexact=self.kwargs["district_number"])

--- a/pems/districts/views.py
+++ b/pems/districts/views.py
@@ -1,4 +1,4 @@
-from django.views.generic import TemplateView
+from django.views.generic import TemplateView, DetailView
 
 from .models import District
 
@@ -17,12 +17,10 @@ class IndexView(DistrictContextMixin, TemplateView):
     template_name = "districts/index.html"
 
 
-class DistrictView(DistrictContextMixin, TemplateView):
+class DistrictView(DistrictContextMixin, DetailView):
+    model = District
+    context_object_name = "district"
     template_name = "districts/district.html"
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        district_number = self.kwargs.get("district")
-        context["district_number"] = district_number
-        context["district"] = context.get("districts").get("all").get(number=district_number)
-        return context
+    def get_object(self):
+        return District.objects.get(number__iexact=self.kwargs["district"])

--- a/pems/districts/views.py
+++ b/pems/districts/views.py
@@ -3,22 +3,26 @@ from django.views.generic import TemplateView
 from .models import District
 
 
-class IndexView(TemplateView):
-    template_name = "districts/index.html"
+class DistrictContextMixin:
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["district_queryset"] = District.objects.all()
+        districts_ctx = {}
+        districts_ctx["all"] = District.objects.all()
+        context["districts"] = districts_ctx
         return context
 
 
-class DistrictView(TemplateView):
+class IndexView(DistrictContextMixin, TemplateView):
+    template_name = "districts/index.html"
+
+
+class DistrictView(DistrictContextMixin, TemplateView):
     template_name = "districts/district.html"
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        district = self.kwargs.get("district")
-        context["url_district"] = district
-        context["district_queryset"] = District.objects.all()
-        context["district_query"] = District.objects.all().get(number=district)
+        district_number = self.kwargs.get("district")
+        context["district_number"] = district_number
+        context["district"] = context.get("districts").get("all").get(number=district_number)
         return context

--- a/pems/districts/views.py
+++ b/pems/districts/views.py
@@ -1,8 +1,15 @@
 from django.views.generic import TemplateView
 
+from .models import District
+
 
 class IndexView(TemplateView):
     template_name = "districts/index.html"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["district_queryset"] = District.objects.all()
+        return context
 
 
 class DistrictView(TemplateView):
@@ -11,5 +18,7 @@ class DistrictView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         district = self.kwargs.get("district")
-        context["district"] = district
+        context["url_district"] = district
+        context["district_queryset"] = District.objects.all()
+        context["district_query"] = District.objects.all().get(number=district)
         return context

--- a/tests/pytest/pems/districts/test_views.py
+++ b/tests/pytest/pems/districts/test_views.py
@@ -4,7 +4,7 @@ from pems.districts import views
 from pems.districts.models import District
 
 
-class TestIndexViewView:
+class TestIndexView:
     @pytest.fixture
     def view(app_request):
         v = views.IndexView()
@@ -17,7 +17,7 @@ class TestIndexViewView:
 
         context = view.get_context_data()
 
-        assert set(context["district_queryset"]) == set(District.objects.all())
+        assert set(context.get("districts").get("all")) == set(District.objects.all())
 
     def test_template_name(self, view):
         assert view.template_name == "districts/index.html"
@@ -37,7 +37,7 @@ class TestDistrictView:
 
         context = view.get_context_data()
 
-        assert context["url_district"] == 1
+        assert context["district_number"] == 1
 
     def test_template_name(self, view):
         assert view.template_name == "districts/district.html"

--- a/tests/pytest/pems/districts/test_views.py
+++ b/tests/pytest/pems/districts/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 
+from django.urls import reverse
 from pems.districts import views
 from pems.districts.models import District
 
@@ -23,21 +24,10 @@ class TestIndexView:
         assert view.template_name == "districts/index.html"
 
 
-class TestDistrictView:
-    @pytest.fixture
-    def view(app_request):
-        v = views.DistrictView()
-        v.setup(app_request, district=1)
+@pytest.mark.django_db
+def test_district_view(client, model_District):
+    url = reverse("districts:district", kwargs={"district": 1})
+    response = client.get(url)
 
-        return v
-
-    @pytest.mark.django_db
-    @pytest.mark.usefixtures("model_District")
-    def test_get_context_data(self, view):
-
-        context = view.get_context_data()
-
-        assert context["district_number"] == 1
-
-    def test_template_name(self, view):
-        assert view.template_name == "districts/district.html"
+    assert response.status_code == 200
+    assert response.context["district"] == model_District

--- a/tests/pytest/pems/districts/test_views.py
+++ b/tests/pytest/pems/districts/test_views.py
@@ -1,6 +1,26 @@
 import pytest
 
 from pems.districts import views
+from pems.districts.models import District
+
+
+class TestIndexViewView:
+    @pytest.fixture
+    def view(app_request):
+        v = views.IndexView()
+        v.setup(app_request)
+
+        return v
+
+    @pytest.mark.django_db
+    def test_get_context_data(self, view):
+
+        context = view.get_context_data()
+
+        assert set(context["district_queryset"]) == set(District.objects.all())
+
+    def test_template_name(self, view):
+        assert view.template_name == "districts/index.html"
 
 
 class TestDistrictView:
@@ -11,11 +31,13 @@ class TestDistrictView:
 
         return v
 
+    @pytest.mark.django_db
+    @pytest.mark.usefixtures("model_District")
     def test_get_context_data(self, view):
 
         context = view.get_context_data()
 
-        assert context["district"] == 1
+        assert context["url_district"] == 1
 
     def test_template_name(self, view):
         assert view.template_name == "districts/district.html"

--- a/tests/pytest/pems/districts/test_views.py
+++ b/tests/pytest/pems/districts/test_views.py
@@ -26,8 +26,8 @@ class TestIndexView:
 
 @pytest.mark.django_db
 def test_district_view(client, model_District):
-    url = reverse("districts:district", kwargs={"district": 1})
+    url = reverse("districts:district", kwargs={"district_number": model_District.number})
     response = client.get(url)
 
     assert response.status_code == 200
-    assert response.context["district"] == model_District
+    assert response.context["current_district"] == model_District


### PR DESCRIPTION
Closes #68

This PR adds UI placeholders for the `districts` application.

## Reviewing

Click around to test out the navigation sidebar to go from all districts to a particular district.

![image](https://github.com/user-attachments/assets/95d159ad-e5e8-4caf-a108-1d61ac8733aa)

