### PR TITLE
Feat: highlight active District in sidebar

### DIFF
--- a/pems/districts/templates/districts/index.html
+++ b/pems/districts/templates/districts/index.html
@@ -8,16 +8,9 @@
     <div class="container p-t-lg">
         <div class="row">
             <div class="col-lg-2 pb-lg-5" role="complementary">
-                <!-- Side navigation -->
-                <nav aria-labelledby="navigation-list" class="side-navigation">
-                    <ul class="list-navigation">
-                        {% for district in districts.all %}
-                            <li>
-                                <a href="{% url 'districts:district' district.number %}">District {{ district.number }}</a>
-                            </li>
-                        {% endfor %}
-                    </ul>
-                </nav>
+                {% block sidebar %}
+                    {% include "districts/navigation.html" %}
+                {% endblock sidebar %}
             </div>
             <div class="col-lg-10 pb-lg-5">
 

--- a/pems/districts/templates/districts/navigation.html
+++ b/pems/districts/templates/districts/navigation.html
@@ -1,0 +1,10 @@
+<!-- Side navigation -->
+<nav aria-labelledby="navigation-list" class="side-navigation">
+    <ul class="list-navigation">
+        {% for d in districts.all %}
+            <li>
+                <a href="{% url 'districts:district' d.number %}" class="{% if d.number == current_district.number %}active{% endif %}">District {{ d.number }}</a>
+            </li>
+        {% endfor %}
+    </ul>
+</nav>


### PR DESCRIPTION
This PR implements highlighting the active District in the navigation sidebar and moves the sidebar to a separate template for modularity.