### PR TITLE
Chore: add AWS dev tools

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,3 +10,29 @@ RUN pip install --no-cache-dir -r docs/requirements.txt
 
 # install streamlit requirements
 RUN pip install --no-cache-dir -r streamlit_app/requirements.txt
+
+# install AWS CLI and Copilot CLI (requires root permissions)
+USER root
+# download AWS CLIs to /tmp to avoid write error (23) from curl command
+WORKDIR /tmp
+RUN HOST_ARCH=$(uname -m) && \
+    case "$HOST_ARCH" in \
+      x86_64) HOST_ARCH="amd64" ;; \
+      aarch64) HOST_ARCH="arm64" ;; \
+    esac \
+    && if [ "$HOST_ARCH" = "amd64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"; \
+    elif [ "$HOST_ARCH" = "arm64" ]; then \
+    curl "https://awscli.amazonaws.com/awscli-exe-linux-aarch64.zip" -o "awscliv2.zip"; \
+    fi \
+    && unzip awscliv2.zip \
+    && ./aws/install \
+    && rm -rf aws awscliv2.zip
+
+RUN curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux \
+    && chmod +x copilot \
+    && mv copilot /usr/local/bin/copilot
+
+# Switch back to non-root user and app directory
+USER $USER
+WORKDIR /$USER/app

--- a/.env.sample
+++ b/.env.sample
@@ -13,3 +13,6 @@ DJANGO_DB_FIXTURES="pems/local_fixtures.json"
 STREAMLIT_LOCAL_PORT=8501
 # options: hidden, sidebar
 STREAMLIT_NAV=hidden
+
+# AWS
+AWS_PROFILE=pems

--- a/compose.yml
+++ b/compose.yml
@@ -20,6 +20,7 @@ services:
     entrypoint: sleep infinity
     volumes:
       - ./:/caltrans/app
+      - ${HOME}/.aws:/home/caltrans/.aws
 
   docs:
     image: caltrans/pems:dev


### PR DESCRIPTION
Closes #107 

<details>
<summary>WIP (for context)</summary>

It's sort of a hassle that the AWS CLI installer is different per platform and that `apt-get` is not updated often, it installs version 2.9 and the current one is 2.27. I would have also thought that the `Linux x86` installer would have worked in the dev container even if the host is a Mac since the base image is multi-platform, but after installation, the `aws` command fails. 

This failure prompted this approach of determining the host architecture ~and passing it as an argument in the build process. The `dev` service successfully builds if we build it using the `bin/build.sh` script. Still trying to see how to work this in to VS Code's "Rebuild and Reopen in Container" command. We need to pass a dynamically generated environment variable like `HOST_ARCH` to the Docker Compose build context during the "Rebuild and Reopen in Container" flow.~ in the Dockerfile since it will return the host machine architecture, which is what we need.
</details>

This PR sets up the dev container so that `aws` and `copilot` commands can be run from the container. It maps the host's AWS credentials folder (for linux `/home/user/.aws` and for mac `/Users/user/.aws`) to the container at `/home/caltrans/.aws` and sets the default AWS profile to use in the dev container to `pems` in the `.env` file.

Note that this PR only installs the tools. The prerequisites to successfully run the tools are:

- The user needs to have their local environment configured for authentication with IAM Identity Center by running `aws configure sso` and going through the setup. You can use the following settings:
  - `SSO session name (Recommended): pems`
  - `SSO start URL [None]: url_provided_by_caltrans`
  - `SSO region [None]: us-west-2`
  - `SSO registration scopes [None]:`
  - `Default client Region [None]: us-west-2`
  - `CLI default output format (json if not specified) [None]:`
  - `Profile name [123456789011_ReadOnly]: pems`
  
- An active SSO session must be available, if it is not, run `aws sso login` inside the container to start a session.

You can confirm that the `pems` profile was configured successfully by running `aws configure list-profiles`.