### PR TITLE
Feat: set up Cloud infrastructure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,8 @@ jobs:
     needs: [tests-ui, tests-pytest]
     permissions:
       packages: write
+      id-token: write
+      contents: read
 
     steps:
       - name: Checkout
@@ -57,34 +59,25 @@ jobs:
       - name: Write tag to file
         run: echo "${{ github.ref_name }}" >> pems/static/version.txt
 
-      - name: Docker Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+      - name: Install AWS Copilot CLI
+        run: |
+          curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+          chmod +x copilot
+          sudo mv copilot /usr/local/bin/copilot
 
-      - name: Set up Docker Buildx
-        id: buildx
-        uses: docker/setup-buildx-action@v3
+      - name: Deploy web Service
+        run: |
+          copilot deploy --name web --env dev
 
-      - name: Build, tag, and push image to GitHub Container Registry
-        uses: docker/build-push-action@v6
-        with:
-          platforms: linux/amd64,linux/arm64
-          builder: ${{ steps.buildx.outputs.name }}
-          build-args: GIT-SHA=${{ github.sha }}
-          cache-from: type=gha,scope=compilerla
-          cache-to: type=gha,scope=compilerla,mode=max
-          context: .
-          file: appcontainer/Dockerfile
-          push: true
-          tags: |
-            ghcr.io/${{ github.repository }}:${{ github.ref_name }}
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+      - name: Deploy streamlit Service
+        run: |
+          copilot deploy --name streamlit --env dev
 
   release:
     needs: deploy

--- a/copilot/.workspace
+++ b/copilot/.workspace
@@ -1,0 +1,1 @@
+application: pems

--- a/copilot/environments/dev/manifest.yml
+++ b/copilot/environments/dev/manifest.yml
@@ -1,0 +1,21 @@
+# The manifest for the "dev" environment.
+# Read the full specification for the "Environment" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/environment/
+
+# Your environment name will be used in naming your resources like VPC, cluster, etc.
+name: dev
+type: Environment
+
+# Import your own VPC and subnets or configure how they should be created.
+# network:
+#   vpc:
+#     id:
+
+# Configure the load balancers in your environment, once created.
+# http:
+#   public:
+#   private:
+
+# Configure observability for your environment resources.
+observability:
+  container_insights: false

--- a/copilot/streamlit/manifest.yml
+++ b/copilot/streamlit/manifest.yml
@@ -1,0 +1,44 @@
+# The manifest for the "streamlit" service.
+# Read the full specification for the "Backend Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/backend-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: streamlit
+type: Backend Service
+
+# Your service is reachable at "http://streamlit.${COPILOT_SERVICE_DISCOVERY_ENDPOINT}:8501" but is not public.
+
+# Configuration for your containers and service.
+image:
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/backend-service/#image-build
+  build:
+    dockerfile: streamlit_app/Dockerfile
+    context: .
+  # Port exposed through your container to route traffic to it.
+  port: 8501
+
+cpu: 256 # Number of CPU units for the task.
+memory: 512 # Amount of memory in MiB used by the task.
+platform: linux/x86_64 # See https://aws.github.io/copilot-cli/docs/manifest/backend-service/#platform
+count: 1 # Number of tasks that should be running in your service.
+exec: true # Enable running commands in your container.
+network:
+  connect: true # Enable Service Connect for intra-environment traffic between services.
+
+# storage:
+# readonly_fs: true       # Limit to read-only access to mounted root filesystems.
+
+# Optional fields for more advanced use-cases.
+#
+#variables:                    # Pass environment variables as key value pairs.
+#  LOG_LEVEL: info
+
+#secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+#  GITHUB_TOKEN: GITHUB_TOKEN  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+
+# You can override any of the values defined above by environment.
+#environments:
+#  test:
+#    count: 2               # Number of tasks to run for the "test" environment.
+#    deployment:            # The deployment strategy for the "test" environment.
+#       rolling: 'recreate' # Stops existing tasks before new ones are started for faster deployments.

--- a/copilot/web/manifest.yml
+++ b/copilot/web/manifest.yml
@@ -1,0 +1,50 @@
+# The manifest for the "web" service.
+# Read the full specification for the "Load Balanced Web Service" type at:
+#  https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/
+
+# Your service name will be used in naming your resources like log groups, ECS services, etc.
+name: web
+type: Load Balanced Web Service
+
+# Distribute traffic to your service.
+http:
+  # Requests to this path will be forwarded to your service.
+  # To match all requests you can use the "/" path.
+  path: '/'
+  # You can specify a custom health check path. The default is "/".
+  healthcheck: '/healthcheck'
+
+# Configuration for your containers and service.
+image:
+  # Docker build arguments. For additional overrides: https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#image-build
+  build:
+    dockerfile: appcontainer/Dockerfile
+    context: .
+  # Port exposed through your container to route traffic to it.
+  port: 8000
+
+cpu: 256       # Number of CPU units for the task.
+memory: 512    # Amount of memory in MiB used by the task.
+platform: linux/x86_64  # See https://aws.github.io/copilot-cli/docs/manifest/lb-web-service/#platform
+count: 1       # Number of tasks that should be running in your service.
+exec: true     # Enable running commands in your container.
+network:
+  connect: true # Enable Service Connect for intra-environment traffic between services.
+
+# storage:
+  # readonly_fs: true       # Limit to read-only access to mounted root filesystems.
+
+# Optional fields for more advanced use-cases.
+#
+#variables:                    # Pass environment variables as key value pairs.
+#  LOG_LEVEL: info
+
+secrets:                      # Pass secrets from AWS Systems Manager (SSM) Parameter Store.
+ DJANGO_ALLOWED_HOSTS: /pems/web/DJANGO_ALLOWED_HOSTS  # The key is the name of the environment variable, the value is the name of the SSM parameter.
+
+# You can override any of the values defined above by environment.
+#environments:
+#  test:
+#    count: 2               # Number of tasks to run for the "test" environment.
+#    deployment:            # The deployment strategy for the "test" environment.
+#       rolling: 'recreate' # Stops existing tasks before new ones are started for faster deployments.

--- a/streamlit_app/Dockerfile
+++ b/streamlit_app/Dockerfile
@@ -1,4 +1,33 @@
-FROM caltrans/pems:app
+ARG PYTHON_VERSION=3.12
+
+FROM python:${PYTHON_VERSION}
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    USER=caltrans
+
+# create non-root $USER and home directory
+RUN useradd --create-home --shell /bin/bash $USER && \
+    # setup directories and permissions
+    mkdir -p /$USER/app && \
+    chown -R $USER:$USER /$USER
+
+# enter source directory
+WORKDIR /$USER
+
+COPY LICENSE app/LICENSE
+
+# switch to non-root $USER
+USER $USER
+
+# update env for local pip installs
+# see https://docs.python.org/3/using/cmdline.html#envvar-PYTHONUSERBASE
+# since all `pip install` commands are in the context of $USER
+# $PYTHONUSERBASE is the location used by default
+ENV PATH="$PATH:/$USER/.local/bin" \
+    PYTHONUSERBASE="/$USER/.local"
+
+WORKDIR /$USER/app
 
 ENV PYTHONPATH="$PYTHONPATH:/$USER/app"
 

--- a/streamlit_app/requirements.txt
+++ b/streamlit_app/requirements.txt
@@ -1,3 +1,4 @@
+django==5.1.6
 pandas==2.2.3
 pygwalker==0.4.9.15
 streamlit==1.44.1


### PR DESCRIPTION
Closes #112, closes #113

This PR sets up the Cloud infrastructure using [AWS Copilot](https://aws.github.io/copilot-cli/) for the following two [services](https://aws.github.io/copilot-cli/docs/concepts/services/) under the `pems` Copilot [application](https://aws.github.io/copilot-cli/docs/concepts/applications/):

- `web`: The web UI/Internet-facing service (Load Balanced Web Service) - successfully deployed manually ✅ 
- `streamlit`: The data visualization via Streamlit service (Back-end Service) - successfully deployed manually ✅ 

It also modifies the `deploy` workflow to deploy the services to an AWS `dev` environment and does not publish the service images to the GitHub Container Registry anymore since the images are now stored on the Amazon Elastic Container Registry.

Separately, an IAM role to connect GitHub Actions to AWS was created following this [AWS reference](https://aws.amazon.com/blogs/security/use-iam-roles-to-connect-github-actions-to-actions-in-aws/).
