### PR TITLE
Fix: install copilot in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,9 +67,10 @@ jobs:
 
       - name: Install AWS Copilot CLI
         run: |
-          curl -Lo copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
-          chmod +x copilot
-          sudo mv copilot /usr/local/bin/copilot
+          mkdir -p ./.tools
+          curl -Lo ./.tools/copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+          chmod +x ./.tools/copilot
+          sudo mv ./.tools/copilot /usr/local/bin/copilot
 
       - name: Deploy web Service
         run: |


### PR DESCRIPTION
We noticed in https://github.com/compilerla/pems/pull/111#issuecomment-2931033629 that there was already a folder called `copilot` in the location where curl was originally trying to install the `copilot` binary.

This fix installs `copilot` in a different directory to avoid the conflict.
