### PR TITLE
Chore: rename compose app service

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM caltrans/pems:app
+FROM caltrans/pems:web
 
 COPY . .
 

--- a/.github/workflows/tests-ui.yml
+++ b/.github/workflows/tests-ui.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
 
-      - name: Start app
+      - name: Start web app
         run: |
           cp .env.sample .env
-          docker compose up --detach app
+          docker compose up --detach web
 
       - name: Run Lighthouse tests for a11y
         uses: treosh/lighthouse-ci-action@12.1.0

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-docker compose build app
+docker compose build web
 
 docker compose build dev
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,11 +1,11 @@
 name: pems
 
 services:
-  app:
+  web:
     build:
       context: .
       dockerfile: appcontainer/Dockerfile
-    image: caltrans/pems:app
+    image: caltrans/pems:web
     env_file: .env
     ports:
       - "${DJANGO_LOCAL_PORT:-8000}:8000"

--- a/docs/development/README.md
+++ b/docs/development/README.md
@@ -152,7 +152,7 @@ Feel free to inspect the environment file, but leave the defaults for now.
 Start the application service with Compose:
 
 ```shell
-docker compose up -d app
+docker compose up -d web
 ```
 
 The `-d` flag starts the service in "detatched" mode, so your terminal is still available for additional commands. Without this flag, your terminal attaches to the service container's standard output.


### PR DESCRIPTION
Closes #115 

This PR renames the compose `app` service to `web` for consistency across local development and AWS `copilot` manifests.