### PR TITLE
Fix: run the copilot CLI from the correct directory

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,10 +75,12 @@ jobs:
       - name: Deploy web Service
         run: |
           copilot deploy --name web --env dev
+        working-directory: ./infra
 
       - name: Deploy streamlit Service
         run: |
           copilot deploy --name streamlit --env dev
+        working-directory: ./infra
 
   release:
     needs: deploy


### PR DESCRIPTION
Closes #134

Run the copilot CLI from the `infra` folder where it can discover the manifests for the copilot app.
