### PR TITLE
Chore: adjust AWS permissions for deploy workflow

### DIFF
--- a/.github/workflows/deploy-troubleshoot.yml
+++ b/.github/workflows/deploy-troubleshoot.yml
@@ -1,0 +1,64 @@
+name: Deploy Troubleshoot
+
+on: workflow_dispatch
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .github/workflows/.python-version
+          cache: pip
+          cache-dependency-path: "**/pyproject.toml"
+
+      - name: Write python packages to file
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+          pip install pipdeptree
+          pip install -e .
+          mkdir -p pems/static
+          pipdeptree
+          pipdeptree >> pems/static/requirements.txt
+
+      - name: Write commit SHA to file
+        run: echo "${{ github.sha }}" >> pems/static/sha.txt
+
+      - name: Write tag to file
+        run: echo "${{ github.ref_name }}" >> pems/static/version.txt
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.ROLE_TO_ASSUME }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Install AWS Copilot CLI
+        run: |
+          mkdir -p ./.tools
+          curl -Lo ./.tools/copilot https://github.com/aws/copilot-cli/releases/latest/download/copilot-linux
+          chmod +x ./.tools/copilot
+          sudo mv ./.tools/copilot /usr/local/bin/copilot
+
+      - name: Deploy web Service
+        run: |
+          copilot deploy --name web --env dev
+        working-directory: ./infra
+
+      - name: Deploy streamlit Service
+        run: |
+          copilot deploy --name streamlit --env dev
+        working-directory: ./infra


### PR DESCRIPTION
@thekaveman  this is a temporary workflow that we can run manually while we troubleshoot AWS permissions issues. When the permissions are set up I'll delete it.

Turns out that even though we can run [deploy.yml](https://github.com/compilerla/pems/blob/main/.github/workflows/deploy.yml) manually, the `tests-pytest` job [fails when run manually](https://github.com/compilerla/pems/actions/runs/15979884343/job/45071571620) because `py-cov-action/python-coverage-comment-action@v3` does not run on `workflow_dispatch`. I think because there is no PR associated with it so it doesn't know where to post the coverage comment. Since this workflow skips tests, it will also help shave off a little time when running it while we adjust the permissions.
