### PR TITLE
Feat: CloudFormation templates for resources not managed by Copilot

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,6 +25,7 @@
         "DavidAnson.vscode-markdownlint",
         "eamodio.gitlens",
         "esbenp.prettier-vscode",
+        "kddejong.vscode-cfn-lint",
         "mhutchie.git-graph",
         "monosans.djlint",
         "ms-python.python",

--- a/infra/cloudformation/gh_actions.yml
+++ b/infra/cloudformation/gh_actions.yml
@@ -1,0 +1,110 @@
+# CloudFormation template for GitHub Actions OIDC Identity Provider and IAM Role.
+# This template creates an IAM OIDC Identity Provider and an IAM Role that allows
+# GitHub Actions to securely authenticate with the PeMS AWS account.
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  CloudFormation template to create an IAM OIDC Identity Provider and
+  IAM Role for GitHub Actions
+
+Parameters:
+  GitHubOrgRepo:
+    Description: Name of GitHub organization and repository (e.g., "my-org/my-repo")
+    Type: String
+
+  Thumbprint:
+    Description: The thumbprint of the GitHub Actions OIDC provider's root CA certificate
+    Type: String
+    Default: d89e3bd43d5d909b47a18977aa9d5ce36cee184c
+
+Resources:
+  GitHubOIDCProvider:
+    Type: "AWS::IAM::OIDCProvider"
+    DeletionPolicy: Delete
+    Properties:
+      ClientIdList:
+        - "sts.amazonaws.com"
+      ThumbprintList:
+        - !Ref Thumbprint
+      Url: "https://token.actions.githubusercontent.com"
+
+  # This IAM Role is assumed by GitHub Actions workflows
+  GitHubActionsRole:
+    Type: "AWS::IAM::Role"
+    DeletionPolicy: Delete
+    Properties:
+      RoleName: "pems-github-actions"
+      Description: Assume and perform GitHub Actions in pems repo of the compilerla GitHub organization
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              # The ARN of the OIDC provider is used as the Federated principal.
+              Federated: !Ref GitHubOIDCProvider
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Condition:
+              StringEquals:
+                "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+              StringLike:
+                "token.actions.githubusercontent.com:sub": !Sub "repo:${GitHubOrgRepo}:*"
+      Policies:
+        - PolicyName: GitHubActionsPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: GetSSMParameterAll
+                Effect: Allow
+                Action: "ssm:GetParameter"
+                Resource: "arn:aws:ssm:us-west-2:715841364638:parameter/copilot/applications/pems/*"
+              - Sid: GetSSMParameter
+                Effect: Allow
+                Action: "ssm:GetParameter"
+                Resource: "arn:aws:ssm:us-west-2:715841364638:parameter/copilot/applications/pems"
+              - Sid: GetSSMParameterByPath
+                Effect: Allow
+                Action: "ssm:GetParametersByPath"
+                Resource: "arn:aws:ssm:us-west-2:715841364638:parameter/copilot/applications/pems/components/"
+              - Sid: AssumeRole
+                Effect: Allow
+                Action: "sts:AssumeRole"
+                Resource: "arn:aws:iam::715841364638:role/pems-dev-EnvManagerRole"
+              - Sid: ListStackInstances
+                Effect: Allow
+                Action: "cloudformation:ListStackInstances"
+                Resource: "arn:aws:cloudformation:us-west-2:715841364638:stackset/pems-infrastructure:ecefc290-0f7f-470a-8b9e-b6a39adf65b7"
+              - Sid: DescribeStacks
+                Effect: Allow
+                Action: "cloudformation:DescribeStacks"
+                Resource: "arn:aws:cloudformation:us-west-2:715841364638:stack/StackSet-pems-infrastructure-c95edbbc-22a7-4239-a10b-7d73ba9344c4/45d26e70-31d1-11f0-a04a-0a0876def005"
+              - Sid: GetAuthorizationToken
+                Effect: Allow
+                Action: "ecr:GetAuthorizationToken"
+                Resource: "*"
+              - Sid: "ECRImagePush"
+                Effect: "Allow"
+                Action:
+                  - "ecr:InitiateLayerUpload"
+                  - "ecr:UploadLayerPart"
+                  - "ecr:CompleteLayerUpload"
+                  - "ecr:PutImage"
+                  - "ecr:BatchCheckLayerAvailability"
+                  - "ecr:GetDownloadUrlForLayer"
+                  - "ecr:GetRepositoryPolicy"
+                  - "ecr:DescribeRepositories"
+                  - "ecr:ListImages"
+                  - "ecr:DescribeImages"
+                  - "ecr:BatchGetImage"
+                  - "ecr:GetLifecyclePolicy"
+                  - "ecr:GetLifecyclePolicyPreview"
+                  - "ecr:ListTagsForResource"
+                  - "ecr:DescribeImageScanFindings"
+                Resource: "arn:aws:ecr:us-west-2:715841364638:repository/pems/*"
+
+Outputs:
+  OIDCProviderArn:
+    Description: The ARN of the created OIDC Provider
+    Value: !Ref GitHubOIDCProvider
+  GitHubActionsRoleArn:
+    Description: The ARN of the IAM Role for GitHub Actions
+    Value: !GetAtt GitHubActionsRole.Arn

--- a/infra/cloudformation/parameter_store.yml
+++ b/infra/cloudformation/parameter_store.yml
@@ -1,0 +1,86 @@
+# CloudFormation template for creating SSM Parameters that are not managed
+# by AWS Copilot.
+
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CloudFormation template to create various parameters in AWS SSM Parameter Store
+
+Parameters:
+  DjangoAllowedHosts:
+    Type: CommaDelimitedList
+    Description: A comma-separated list of host/domain names that a Django application is permitted to serve
+    Default: "*"
+  DjangoDBFixtures:
+    Type: String
+    Description: Name of Django database fixtures json file
+    Default: "fixtures.json"
+  DjangoDBName:
+    Type: String
+    Description: Name of Django database
+    Default: "django"
+  DjangoDBUser:
+    Type: String
+    Description: Name of user for Django database
+    Default: "django"
+  DjangoDBPassword:
+    Type: String
+    Description: Password of user for Django database
+    Default: "django_password"
+
+Resources:
+  DjangoAllowedHostsParameter:
+    Type: "AWS::SSM::Parameter"
+    DeletionPolicy: Delete
+    Properties:
+      Name: /pems/web/DJANGO_ALLOWED_HOSTS
+      Description: Django security setting that defines a list of host/domain names that a Django application is permitted to serve
+      Type: StringList
+      Value: !Join [",", !Ref DjangoAllowedHosts]
+  DjangoDBFixturesParameter:
+    Type: "AWS::SSM::Parameter"
+    DeletionPolicy: Delete
+    Properties:
+      Name: /pems/web/DJANGO_DB_FIXTURES
+      Description: Name of Django database fixtures json file
+      Type: String
+      Value: !Ref DjangoDBFixtures
+  DjangoDBNameParameter:
+    Type: "AWS::SSM::Parameter"
+    DeletionPolicy: Delete
+    Properties:
+      Name: /pems/web/DJANGO_DB_NAME
+      Description: Name of Django database
+      Type: String
+      Value: !Ref DjangoDBName
+  DjangoDBUserParameter:
+    Type: "AWS::SSM::Parameter"
+    DeletionPolicy: Delete
+    Properties:
+      Name: /pems/web/DJANGO_DB_USER
+      Description: Name of user for Django database
+      Type: String
+      Value: !Ref DjangoDBUser
+  DjangoDBPasswordParameter:
+    Type: "AWS::SSM::Parameter"
+    DeletionPolicy: Delete
+    Properties:
+      Name: /pems/web/DJANGO_DB_PASSWORD
+      Description: Password of user for Django database
+      Type: String
+      Value: !Ref DjangoDBPassword
+
+Outputs:
+  DjangoAllowedHostsParameterName:
+    Description: Name of the DJANGO_ALLOWED_HOSTS SSM Parameter
+    Value: !Ref DjangoAllowedHostsParameter
+  DjangoDBFixturesParameterName:
+    Description: Name of the DJANGO_DB_FIXTURES SSM Parameter
+    Value: !Ref DjangoDBFixturesParameter
+  DjangoDBNameParameterName:
+    Description: Name of the DJANGO_DB_NAME SSM Parameter
+    Value: !Ref DjangoDBNameParameter
+  DjangoDBUserParameterName:
+    Description: Name of the DJANGO_DB_USER SSM Parameter
+    Value: !Ref DjangoDBUserParameter
+  DjangoDBPasswordParameterName:
+    Description: Name of the DJANGO_DB_PASSWORD SSM Parameter
+    Value: !Ref DjangoDBPasswordParameter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["black", "djlint", "flake8", "pre-commit", "setuptools_scm>=8"]
+dev = [
+    "black",
+    "cfn-lint",
+    "djlint",
+    "flake8",
+    "pre-commit",
+    "setuptools_scm>=8",
+]
 
 test = ["coverage", "pytest", "pytest-django", "pytest-mock", "pytest-socket"]
 


### PR DESCRIPTION
This PR, related to #144, commits CloudFormation templates for resources that are not managed by AWS Copilot:

- GitHub Actions Identity Provider and Role
- Parameter Store Parameters

In addition, it adds a [template linter](https://github.com/aws-cloudformation/cfn-lint) and its [VS Code extension](https://marketplace.visualstudio.com/items?itemName=kddejong.vscode-cfn-lint) to the dev container.
