### PR TITLE
Fix: typo in `update-stack` command

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Update GitHub connection-related AWS resources
         run: |
           aws cloudformation update-stack \
-          --stack-name pems-github-actions
+          --stack-name pems-github-actions \
           --template-body file://infra/cloudformation/gh_actions.yaml \
           --capabilities CAPABILITY_IAM
 


### PR DESCRIPTION
This PR fixes a typo (missing a backslash at the end of a line) in the `aws cloudformation update-stack` command in the `Deploy` workflow that was responsible for this failed [workflow run](https://github.com/compilerla/pems/actions/runs/16267816236/job/45927629178).
