### PR TITLE
Fix: deployment environment name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,11 +87,11 @@ jobs:
           sudo mv ./.tools/copilot /usr/local/bin/copilot
 
       - name: Deploy web Service
-        run: copilot deploy --name web --env ${{ github.environment }}
+        run: copilot deploy --name web --env ${{ vars.ENVIRONMENT_NAME }}
         working-directory: ./infra
 
       - name: Deploy streamlit Service
-        run: copilot deploy --name streamlit --env ${{ github.environment }}
+        run: copilot deploy --name streamlit --env ${{ vars.ENVIRONMENT_NAME }}
         working-directory: ./infra
 
   release:


### PR DESCRIPTION
Although some references suggested that `github.environment` could be used to obtain the environment's name, testing the workflow showed that `github.environment` is actually not available in the context.

Instead, we set `ENVIRONMENT_NAME` for each environment and use`vars.ENVIRONMENT_NAME` to get the name of the deployment environment for the workflow. This will fix the failed [workflow run](https://github.com/compilerla/pems/actions/runs/16298115294/job/46025312212).
