### PR TITLE
Fix: policy to access the S3 marts bucket

### DIFF
--- a/infra/copilot/streamlit/addons/s3-marts-access-policy.yml
+++ b/infra/copilot/streamlit/addons/s3-marts-access-policy.yml
@@ -8,9 +8,6 @@ Parameters:
   Name:
     Type: String
     Description: Your workload's name.
-  TaskRole:
-    Type: String
-    Description: The ARN of the task role.
 
 Resources:
   S3martsBucketAccessPolicy:
@@ -19,7 +16,7 @@ Resources:
       PolicyName: s3martsBucketPolicy
       # Attach this policy to the TaskRole provided by Copilot.
       Roles:
-        - !Ref TaskRole
+        - "pems-dev-streamlit-TaskRole-5Zuwi15thMkN"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/infra/copilot/streamlit/addons/s3-marts-access-policy.yml
+++ b/infra/copilot/streamlit/addons/s3-marts-access-policy.yml
@@ -11,12 +11,9 @@ Parameters:
 
 Resources:
   S3martsBucketAccessPolicy:
-    Type: AWS::IAM::Policy
+    Type: AWS::IAM::ManagedPolicy
     Properties:
-      PolicyName: s3martsBucketPolicy
-      # Attach this policy to the TaskRole provided by Copilot.
-      Roles:
-        - "pems-dev-streamlit-TaskRole-5Zuwi15thMkN"
+      Description: "Access to S3 marts bucket"
       PolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -30,6 +27,6 @@ Resources:
             Resource: "arn:aws:s3:::caltrans-pems-prd-us-west-2-marts"
 
 Outputs:
-  S3martsAccessPolicyArn:
-    Description: "The ARN of the S3 marts access policy"
+  S3martsBucketAccessPolicyArn:
+    Description: "The ARN of the S3 marts bucket access policy"
     Value: !Ref S3martsBucketAccessPolicy

--- a/infra/copilot/streamlit/addons/s3-marts-access-policy.yml
+++ b/infra/copilot/streamlit/addons/s3-marts-access-policy.yml
@@ -1,0 +1,38 @@
+Parameters:
+  App:
+    Type: String
+    Description: Your application's name.
+  Env:
+    Type: String
+    Description: The environment name your service, job, or workflow is being deployed to.
+  Name:
+    Type: String
+    Description: Your workload's name.
+  TaskRole:
+    Type: String
+    Description: The ARN of the task role.
+
+Resources:
+  S3martsBucketAccessPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: s3martsBucketPolicy
+      # Attach this policy to the TaskRole provided by Copilot.
+      Roles:
+        - !Ref TaskRole
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: S3ObjectActions
+            Effect: Allow
+            Action: s3:GetObject
+            Resource: "arn:aws:s3:::caltrans-pems-prd-us-west-2-marts/*"
+          - Sid: S3ListAction
+            Effect: Allow
+            Action: s3:ListBucket
+            Resource: "arn:aws:s3:::caltrans-pems-prd-us-west-2-marts"
+
+Outputs:
+  S3martsAccessPolicyArn:
+    Description: "The ARN of the S3 marts access policy"
+    Value: !Ref S3martsBucketAccessPolicy


### PR DESCRIPTION
Closes #185

Add a policy (as a Copilot addon) for accessing the S3 marts bucket from the ECS `streamlit` task via its Task role.

## Notes

Using a `ManagedPolicy` is the most straightforward way to add permissions to the Copilot-created  ECS `streamlit` [`TaskRole`](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html).
To see how the CloudFormation templates created by Copilot will look like when adding the `s3-marts-access-policy` addon, run

```
copilot svc package --name streamlit --env dev --output-dir .
```

from the `infra` folder. The command will create 3 files (parameters, main stack template, and addon stack template) in `infra`. The addon stack template is essentially the template in this PR (with a few formatting changes) and the main stack template and parameters are what the Copilot CLI will produce to send to CloudFormation to create the stack. The key section of the main stack, where the link is made with the permissions defined in the addon, is shown below

```
...
  TaskRole:
    Metadata:
      'aws:copilot:description': 'An IAM role to control permissions for the containers in your tasks'
    Type: AWS::IAM::Role
    Properties:
      ManagedPolicyArns:
        - Fn::GetAtt: [AddonsStack, Outputs.S3martsBucketAccessPolicyArn]
 ...
 ```
 
Note that there is no mention of the environment in the addon stack because accessing the S3 marts bucket is not dependent on the environment, all environments will access the same S3 bucket with the same permissions.
