### PR TITLE
Chore: add CODEOWNERS for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,5 @@
 # default to pems-admin team
 * @compilerla/pems-admin
+
+# pems team can approve docs
+docs/* @compilerla/pems


### PR DESCRIPTION
So @compilerla/pems can approve changes to PeMS documentation.