### PR TITLE
Fix: Add titles to iframes for accessibility

### DIFF
--- a/pems_web/src/pems_web/districts/templates/districts/district.html
+++ b/pems_web/src/pems_web/districts/templates/districts/district.html
@@ -12,7 +12,9 @@
     </div>
     <div class="row" style="min-height: 450px;">
         <div class="col-lg-12 border">
-            <iframe class="w-100 h-100" src="{{ streamlit.url }}/stations--stations?embed=true&district_number={{ current_district.number }}">
+            <iframe title="District {{ current_district.number }} visualization"
+                    class="w-100 h-100"
+                    src="{{ streamlit.url }}/stations--stations?embed=true&district_number={{ current_district.number }}">
             </iframe>
         </div>
     </div>

--- a/pems_web/src/pems_web/districts/templates/districts/index.html
+++ b/pems_web/src/pems_web/districts/templates/districts/index.html
@@ -24,7 +24,7 @@
                     </div>
                     <div class="row" style="min-height: 450px;">
                         <div class="col-lg-12 border">
-                            <iframe class="w-100 h-100" src="{{ streamlit.url }}/stations--stations?embed=true">
+                            <iframe title="District visualizations" class="w-100 h-100" src="{{ streamlit.url }}/stations--stations?embed=true">
                             </iframe>
                         </div>
                     </div>


### PR DESCRIPTION
closes #180

## What this PR does
- Adds `title` with a human-readable value describing the contents in the <iframe> for all <iframes>

## Guidance
- All streamlit <iframes> need to have a `title` that describes the content

## What to review for
- Is there a better way to describe the data?
- Run Axe-Core DevTools extension to check, and look at the rendered HTML.
