### PR TITLE
Feat: `pems_data` caching

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "caltrans/pems",
   "dockerComposeFile": ["../compose.yml"],
   "service": "dev",
-  "runServices": ["dev", "pgweb"],
+  "runServices": ["dev", "pgweb", "redis"],
   "forwardPorts": ["docs:8000"],
   "workspaceFolder": "/caltrans/app",
   "postStartCommand": ["/bin/bash", "bin/setup.sh"],

--- a/.env.sample
+++ b/.env.sample
@@ -27,3 +27,7 @@ STREAMLIT_NAV=hidden
 
 # AWS
 AWS_PROFILE=pems
+
+# Redis
+REDIS_PORT=6379
+REDIS_HOSTNAME=redis

--- a/compose.yml
+++ b/compose.yml
@@ -75,6 +75,21 @@ services:
     ports:
       - "${STREAMLIT_LOCAL_PORT:-8501}:8501"
 
+  redis:
+    image: redis:8
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    command: redis-server --save 60 1 --loglevel notice
+    healthcheck:
+      test: redis-cli ping | grep PONG
+      interval: 1s
+      timeout: 5s
+      retries: 5
+    volumes:
+      - redisdata:/data
+
 volumes:
   pgdata:
+    driver: local
+  redisdata:
     driver: local

--- a/pems_data/pyproject.toml
+++ b/pems_data/pyproject.toml
@@ -3,7 +3,12 @@ name = "pems_data"
 description = "Common data access library for PeMS."
 dynamic = ["version"]
 requires-python = ">=3.12"
-dependencies = ["boto3==1.39.7", "pandas==2.3.0", "redis==6.2.0"]
+dependencies = [
+    "boto3==1.39.7",
+    "pandas==2.3.0",
+    "pyarrow==21.0.0",
+    "redis==6.2.0",
+]
 
 [project.scripts]
 pems-cache = "pems_data.cli:cache"

--- a/pems_data/pyproject.toml
+++ b/pems_data/pyproject.toml
@@ -3,7 +3,7 @@ name = "pems_data"
 description = "Common data access library for PeMS."
 dynamic = ["version"]
 requires-python = ">=3.12"
-dependencies = ["boto3==1.39.7", "pandas==2.3.0"]
+dependencies = ["boto3==1.39.7", "pandas==2.3.0", "redis==6.2.0"]
 
 [build-system]
 requires = ["setuptools>=75", "setuptools_scm>=8"]

--- a/pems_data/pyproject.toml
+++ b/pems_data/pyproject.toml
@@ -5,6 +5,9 @@ dynamic = ["version"]
 requires-python = ">=3.12"
 dependencies = ["boto3==1.39.7", "pandas==2.3.0", "redis==6.2.0"]
 
+[project.scripts]
+pems-cache = "pems_data.cli:cache"
+
 [build-system]
 requires = ["setuptools>=75", "setuptools_scm>=8"]
 build-backend = "setuptools.build_meta"

--- a/pems_data/src/pems_data/__init__.py
+++ b/pems_data/src/pems_data/__init__.py
@@ -1,0 +1,21 @@
+from pems_data.cache import Cache
+from pems_data.services.stations import StationsService
+from pems_data.sources.cache import CachingDataSource
+from pems_data.sources.s3 import S3DataSource
+
+
+class ServiceFactory:
+    """
+    A factory class to create and configure various services.
+
+    Shared dependencies are created once during initialization.
+    """
+
+    def __init__(self):
+        self.cache = Cache()
+        self.s3_source = S3DataSource()
+        self.caching_s3_source = CachingDataSource(data_source=self.s3_source, cache=self.cache)
+
+    def stations_service(self) -> StationsService:
+        """Creates a fully-configured `StationsService`."""
+        return StationsService(data_source=self.caching_s3_source)

--- a/pems_data/src/pems_data/cache.py
+++ b/pems_data/src/pems_data/cache.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Any
+from typing import Any, Callable
 
 import redis
 
@@ -27,22 +27,28 @@ class Cache:
         logger.debug(f"cache is available: {available}")
         return available
 
-    def get(self, key: str) -> Any:
+    def get(self, key: str, mutate_func: Callable[[Any], Any] = None) -> Any:
         """Get a raw value from the cache, or None if the key doesn't exist.
 
         Args:
             key (str): The item's cache key.
+            mutate_func (callable): If provided, call this on the cached value and return its result.
         """
         logger.debug(f"read from cache: {key}")
         value = self.r.get(key)
+        if value and mutate_func:
+            return mutate_func(value)
         return value
 
-    def set(self, key: str, value: Any) -> None:
+    def set(self, key: str, value: Any, mutate_func: Callable[[Any], Any] = None) -> None:
         """Set a value in the cache.
 
         Args:
             key (str): The item's cache key.
             value (Any): The item's value to store in the cache.
+            mutate_func (callable): If provided, call this on the value and insert the result in the cache.
         """
+        if mutate_func:
+            value = mutate_func(value)
         logger.debug(f"store in cache: {key}")
         self.r.set(key, value)

--- a/pems_data/src/pems_data/cache.py
+++ b/pems_data/src/pems_data/cache.py
@@ -2,7 +2,10 @@ import logging
 import os
 from typing import Any, Callable
 
+import pandas as pd
 import redis
+
+from pems_data.serialization import arrow_bytes_to_df, df_to_arrow_bytes
 
 logger = logging.getLogger(__name__)
 
@@ -76,6 +79,10 @@ class Cache:
         logger.warning(f"cache unavailable to get: {key}")
         return None
 
+    def get_df(self, key: str) -> pd.DataFrame:
+        """Get a `pandas.DataFrame` from the cache, or None if the key doesn't exist."""
+        return self.get(key, mutate_func=arrow_bytes_to_df)
+
     def set(self, key: str, value: Any, mutate_func: Callable[[Any], Any] = None) -> None:
         """Set a value in the cache.
 
@@ -92,3 +99,7 @@ class Cache:
             self.c.set(key, value)
         else:
             logger.warning(f"cache unavailable to set: {key}")
+
+    def set_df(self, key: str, value: pd.DataFrame) -> None:
+        """Set a `pandas.DataFrame` in the cache."""
+        self.set(key, value, mutate_func=df_to_arrow_bytes)

--- a/pems_data/src/pems_data/cache.py
+++ b/pems_data/src/pems_data/cache.py
@@ -38,6 +38,11 @@ def redis_connection(host: str = None, port: int = None, **kwargs) -> redis.Redi
 class Cache:
     """Basic caching interface for `pems_data`."""
 
+    @classmethod
+    def build_key(cls, *args) -> str:
+        """Build a cache key from the given parts."""
+        return ":".join([str(a).lower() for a in args])
+
     def __init__(self, host: str = None, port: int = None):
         """Create a new instance of the Cache interface.
 

--- a/pems_data/src/pems_data/cache.py
+++ b/pems_data/src/pems_data/cache.py
@@ -1,0 +1,48 @@
+import logging
+import os
+from typing import Any
+
+import redis
+
+logger = logging.getLogger(__name__)
+
+
+def redis_connection() -> redis.Redis:
+    hostname = os.environ.get("REDIS_HOSTNAME", "redis")
+    port = int(os.environ.get("REDIS_PORT", "6379"))
+
+    logger.debug(f"Connecting to redis @ {hostname}:{port}")
+    return redis.Redis(host=hostname, port=port)
+
+
+class Cache:
+    """Basic caching interface for `pems_data`."""
+
+    def __init__(self):
+        self.r = redis_connection()
+
+    def is_available(self) -> bool:
+        """Return a bool indicating if the cache backend is available or not."""
+        available = self.r.ping() is True
+        logger.debug(f"cache is available: {available}")
+        return available
+
+    def get(self, key: str) -> Any:
+        """Get a raw value from the cache, or None if the key doesn't exist.
+
+        Args:
+            key (str): The item's cache key.
+        """
+        logger.debug(f"read from cache: {key}")
+        value = self.r.get(key)
+        return value
+
+    def set(self, key: str, value: Any) -> None:
+        """Set a value in the cache.
+
+        Args:
+            key (str): The item's cache key.
+            value (Any): The item's value to store in the cache.
+        """
+        logger.debug(f"store in cache: {key}")
+        self.r.set(key, value)

--- a/pems_data/src/pems_data/cache.py
+++ b/pems_data/src/pems_data/cache.py
@@ -88,12 +88,13 @@ class Cache:
         """Get a `pandas.DataFrame` from the cache, or None if the key doesn't exist."""
         return self.get(key, mutate_func=arrow_bytes_to_df)
 
-    def set(self, key: str, value: Any, mutate_func: Callable[[Any], Any] = None) -> None:
+    def set(self, key: str, value: Any, ttl: int = None, mutate_func: Callable[[Any], Any] = None) -> None:
         """Set a value in the cache.
 
         Args:
             key (str): The item's cache key.
             value (Any): The item's value to store in the cache.
+            ttl (int): Seconds until expiration.
             mutate_func (callable): If provided, call this on the value and insert the result in the cache.
         """
         if self.is_available():
@@ -101,10 +102,10 @@ class Cache:
                 logger.debug(f"mutating value for cache: {key}")
                 value = mutate_func(value)
             logger.debug(f"store in cache: {key}")
-            self.c.set(key, value)
+            self.c.set(key, value, ex=ttl)
         else:
             logger.warning(f"cache unavailable to set: {key}")
 
-    def set_df(self, key: str, value: pd.DataFrame) -> None:
-        """Set a `pandas.DataFrame` in the cache."""
-        self.set(key, value, mutate_func=df_to_arrow_bytes)
+    def set_df(self, key: str, value: pd.DataFrame, ttl: int = None) -> None:
+        """Set a `pandas.DataFrame` in the cache, with an optional TTL (seconds until expiration)."""
+        self.set(key, value, mutate_func=df_to_arrow_bytes, ttl=ttl)

--- a/pems_data/src/pems_data/cli.py
+++ b/pems_data/src/pems_data/cli.py
@@ -1,0 +1,31 @@
+import argparse
+import sys
+
+from pems_data.cache import Cache
+
+
+def cache():  # prama: no cover
+    parser = argparse.ArgumentParser("pems-cache", description="Simple CLI for the cache")
+    parser.add_argument("op", choices=("check", "get", "set"), default="check", nargs="?", help="the operation to perform")
+    parser.add_argument("--key", "-k", required=False, type=str, help="the item's key, required for get/set")
+    parser.add_argument("--value", "-v", required=False, type=str, help="the item's value, required for set")
+    parsed_args = parser.parse_args(sys.argv[1:])
+
+    c = Cache()
+
+    match parsed_args.op:
+        case "get":
+            if parsed_args.key:
+                print(f"[{parsed_args.key}]: {c.get(parsed_args.key)}")
+            else:
+                parser.print_usage()
+                raise SystemExit(1)
+        case "set":
+            if parsed_args.key and parsed_args.value:
+                print(f"[{parsed_args.key}] = '{parsed_args.value}'")
+                c.set(parsed_args.key, parsed_args.value)
+            else:
+                parser.print_usage()
+                raise SystemExit(1)
+        case _:
+            print(f"cache is available: {c.is_available()}")

--- a/pems_data/src/pems_data/serialization.py
+++ b/pems_data/src/pems_data/serialization.py
@@ -1,0 +1,29 @@
+import pandas as pd
+import pyarrow as pa
+import pyarrow.ipc as ipc
+
+
+def arrow_bytes_to_df(arrow_buffer: bytes) -> pd.DataFrame:
+    """Deserializes Arrow IPC format `bytes` back to a `pandas.DataFrame`."""
+    if not arrow_buffer:
+        return pd.DataFrame()
+    # deserialize the Arrow IPC stream
+    with pa.BufferReader(arrow_buffer) as buffer:
+        # the reader reconstructs the Arrow Table from the buffer
+        reader = ipc.RecordBatchStreamReader(buffer)
+        arrow_table = reader.read_all()
+    return arrow_table.to_pandas()
+
+
+def df_to_arrow_bytes(df: pd.DataFrame) -> bytes:
+    """Serializes a `pandas.DataFrame` to Arrow IPC format `bytes`."""
+    if df.empty:
+        return b""
+    # convert DataFrame to an Arrow Table
+    arrow_table = pa.Table.from_pandas(df, preserve_index=False)
+    # serialize the Arrow Table to bytes using the IPC stream format
+    sink = pa.BufferOutputStream()
+    with ipc.RecordBatchStreamWriter(sink, arrow_table.schema) as writer:
+        writer.write_table(arrow_table)
+    # get the buffer from the stream
+    return sink.getvalue().to_pybytes()

--- a/pems_data/src/pems_data/sources/cache.py
+++ b/pems_data/src/pems_data/sources/cache.py
@@ -1,0 +1,30 @@
+import pandas as pd
+
+from pems_data.cache import Cache
+from pems_data.sources import IDataSource
+
+
+class CachingDataSource(IDataSource):
+    """
+    A DataSource decorator that adds a caching layer to another data source.
+    """
+
+    def __init__(self, data_source: IDataSource, cache: Cache):
+        self.cache = cache
+        self.data_source = data_source
+
+    def read(self, identifier: str, **kwargs) -> pd.DataFrame:
+        # use cache key from the arguments, fallback to identifier
+        cache_key = kwargs.get("cache_key", identifier)
+
+        # try to get df from cache
+        cached_df = self.cache.get_df(cache_key)
+        if cached_df is not None:
+            return cached_df
+
+        # on miss, call the wrapped source
+        df = self.data_source.read(identifier, **kwargs)
+        # store the result in the cache
+        self.cache.set_df(cache_key, df)
+
+        return df

--- a/pems_data/src/pems_data/sources/cache.py
+++ b/pems_data/src/pems_data/sources/cache.py
@@ -14,8 +14,11 @@ class CachingDataSource(IDataSource):
         self.data_source = data_source
 
     def read(self, identifier: str, **kwargs) -> pd.DataFrame:
-        # use cache key from the arguments, fallback to identifier
-        cache_key = kwargs.get("cache_key", identifier)
+        # get cache options from kwargs
+        cache_opts = kwargs.pop("cache_opts", {})
+        # use cache key from options, fallback to identifier
+        cache_key = cache_opts.get("key", identifier)
+        ttl = cache_opts.get("ttl")
 
         # try to get df from cache
         cached_df = self.cache.get_df(cache_key)
@@ -25,6 +28,6 @@ class CachingDataSource(IDataSource):
         # on miss, call the wrapped source
         df = self.data_source.read(identifier, **kwargs)
         # store the result in the cache
-        self.cache.set_df(cache_key, df)
+        self.cache.set_df(cache_key, df, ttl=ttl)
 
         return df

--- a/pems_streamlit/src/pems_streamlit/apps/stations/app_stations.py
+++ b/pems_streamlit/src/pems_streamlit/apps/stations/app_stations.py
@@ -3,11 +3,11 @@ import re
 import pandas as pd
 import streamlit as st
 
-from pems_data.sources.s3 import S3DataSource
-from pems_data.services.stations import StationsService
+from pems_data import ServiceFactory
 
-BUCKET = S3DataSource()
-STATIONS = StationsService(data_source=BUCKET)
+FACTORY = ServiceFactory()
+STATIONS = FACTORY.stations_service()
+S3 = FACTORY.s3_source
 
 
 @st.cache_data(ttl=3600)  # Cache for 1 hour
@@ -28,7 +28,7 @@ def get_available_days() -> set:
     def match(m: re.Match):
         return int(m.group(1))
 
-    return BUCKET.get_prefixes(pattern, initial_prefix=STATIONS.imputation_detector_agg_5min, match_func=match)
+    return S3.get_prefixes(pattern, initial_prefix=STATIONS.imputation_detector_agg_5min, match_func=match)
 
 
 @st.cache_data(ttl=300)  # Cache for 5 minutes

--- a/tests/pytest/pems_data/conftest.py
+++ b/tests/pytest/pems_data/conftest.py
@@ -1,0 +1,7 @@
+import pandas as pd
+import pytest
+
+
+@pytest.fixture
+def df() -> pd.DataFrame:
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})

--- a/tests/pytest/pems_data/conftest.py
+++ b/tests/pytest/pems_data/conftest.py
@@ -5,3 +5,16 @@ import pytest
 @pytest.fixture
 def df() -> pd.DataFrame:
     return pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+
+
+@pytest.fixture(autouse=True)
+def mock_s3(mocker):
+    s3 = mocker.patch("boto3.client").return_value
+    s3.list_objects.return_value = {
+        "Contents": [
+            {"Key": "path1/file2.json"},
+            {"Key": "path2/file1.json"},
+            {"Key": "path1/file1.json"},
+        ]
+    }
+    return s3

--- a/tests/pytest/pems_data/sources/test_cache.py
+++ b/tests/pytest/pems_data/sources/test_cache.py
@@ -1,0 +1,48 @@
+import pandas as pd
+import pytest
+
+from pems_data.sources import IDataSource
+from pems_data.sources.cache import CachingDataSource
+
+
+class TestCachingDataSource:
+    @pytest.fixture
+    def mock_source(self, df):
+        """Create a mock underlying data source"""
+
+        class MockSource(IDataSource):
+            def read(self, identifier: str, **kwargs) -> pd.DataFrame:
+                return df
+
+        return MockSource()
+
+    @pytest.fixture
+    def mock_cache(self, mocker):
+        """Create and configure mock cache"""
+        cache = mocker.Mock()
+        cache.is_available.return_value = True
+        return cache
+
+    @pytest.fixture
+    def data_source(self, mock_source, mock_cache) -> CachingDataSource:
+        """Create CachingDataSource with mocked dependencies"""
+        return CachingDataSource(mock_source, cache=mock_cache)
+
+    def test_read__cache_hit(self, data_source: CachingDataSource, mock_cache, df):
+        """Test reading when data is in cache"""
+        mock_cache.get_df.return_value = df
+
+        result = data_source.read("test-id")
+
+        mock_cache.get_df.assert_called_once_with("test-id")
+        pd.testing.assert_frame_equal(result, df)
+
+    def test_read__cache_miss(self, data_source: CachingDataSource, mock_cache, df):
+        """Test reading when data is not in cache"""
+        mock_cache.get_df.return_value = None
+
+        result = data_source.read("test-id")
+
+        mock_cache.get_df.assert_called_once_with("test-id")
+        mock_cache.set_df.assert_called_once_with("test-id", df)
+        pd.testing.assert_frame_equal(result, df)

--- a/tests/pytest/pems_data/sources/test_cache.py
+++ b/tests/pytest/pems_data/sources/test_cache.py
@@ -44,5 +44,5 @@ class TestCachingDataSource:
         result = data_source.read("test-id")
 
         mock_cache.get_df.assert_called_once_with("test-id")
-        mock_cache.set_df.assert_called_once_with("test-id", df)
+        mock_cache.set_df.assert_called_once_with("test-id", df, ttl=None)
         pd.testing.assert_frame_equal(result, df)

--- a/tests/pytest/pems_data/sources/test_s3.py
+++ b/tests/pytest/pems_data/sources/test_s3.py
@@ -12,18 +12,6 @@ class TestS3DataSource:
         return S3DataSource()
 
     @pytest.fixture(autouse=True)
-    def mock_s3(self, mocker):
-        s3 = mocker.patch("boto3.client").return_value
-        s3.list_objects.return_value = {
-            "Contents": [
-                {"Key": "path1/file2.json"},
-                {"Key": "path2/file1.json"},
-                {"Key": "path1/file1.json"},
-            ]
-        }
-        return s3
-
-    @pytest.fixture(autouse=True)
     def mock_read_parquet(self, mocker):
         return mocker.patch("pandas.read_parquet")
 

--- a/tests/pytest/pems_data/test_cache.py
+++ b/tests/pytest/pems_data/test_cache.py
@@ -108,6 +108,26 @@ class TestCache:
         spy_connect.assert_called_once()
         mock_redis_connection.get.assert_called_once_with("test-key")
 
+    def test_get__cache_unavailable(self, cache: Cache, mock_redis_connection, spy_connect):
+        # simulate cache unavailable
+        mock_redis_connection.ping.return_value = False
+
+        result = cache.get("test-key")
+
+        assert result is None
+        spy_connect.assert_called_once()
+        mock_redis_connection.get.assert_not_called()
+
+    def test_get__key_missing(self, cache: Cache, mock_redis_connection, mocker, spy_connect):
+        # simulate key missing in cache
+        mock_redis_connection.get.return_value = None
+
+        result = cache.get("missing-key")
+
+        spy_connect.assert_called_once()
+        mock_redis_connection.get.assert_called_once_with("missing-key")
+        assert result is None
+
     def test_get__mutate(self, cache: Cache, mock_redis_connection, spy_connect):
         expected = 2
         mock_redis_connection.get.return_value = 1

--- a/tests/pytest/pems_data/test_cache.py
+++ b/tests/pytest/pems_data/test_cache.py
@@ -73,6 +73,9 @@ class TestCache:
     def mock_is_available(self, mock_redis_connection):
         mock_redis_connection.ping.return_value = True
 
+    def test_build_key(self, cache: Cache):
+        assert cache.build_key("one", "TWO", 3) == "one:two:3"
+
     def test_init_does_not_create_redis_connection(self, cache: Cache, spy_connect):
         assert hasattr(cache, "c")
         assert cache.c is None

--- a/tests/pytest/pems_data/test_cache.py
+++ b/tests/pytest/pems_data/test_cache.py
@@ -57,7 +57,23 @@ class TestCache:
         assert result == expected
         mock_redis_connection.get.assert_called_once_with("test-key")
 
+    def test_get_mutate(self, cache: Cache, mock_redis_connection):
+        expected = 2
+        mock_redis_connection.get.return_value = 1
+
+        result = cache.get("test-key", lambda v: v + 1)
+
+        assert result == expected
+        mock_redis_connection.get.assert_called_once_with("test-key")
+
     def test_set(self, cache: Cache, mock_redis_connection):
         cache.set("test-key", "test-value")
 
         mock_redis_connection.set.assert_called_once_with("test-key", "test-value")
+
+    def test_set_mutate(self, cache: Cache, mock_redis_connection):
+        expected = 2
+
+        cache.set("test-key", 1, lambda v: v + 1)
+
+        mock_redis_connection.set.assert_called_once_with("test-key", expected)

--- a/tests/pytest/pems_data/test_cache.py
+++ b/tests/pytest/pems_data/test_cache.py
@@ -135,7 +135,7 @@ class TestCache:
         expected = 2
         mock_redis_connection.get.return_value = 1
 
-        result = cache.get("test-key", lambda v: v + 1)
+        result = cache.get("test-key", mutate_func=lambda v: v + 1)
 
         assert result == expected
         spy_connect.assert_called_once()
@@ -145,15 +145,23 @@ class TestCache:
         cache.set("test-key", "test-value")
 
         spy_connect.assert_called_once()
-        mock_redis_connection.set.assert_called_once_with("test-key", "test-value")
+        mock_redis_connection.set.assert_called_once_with("test-key", "test-value", ex=None)
 
     def test_set__mutate(self, cache: Cache, mock_redis_connection, spy_connect):
         expected = 2
 
-        cache.set("test-key", 1, lambda v: v + 1)
+        cache.set("test-key", 1, mutate_func=lambda v: v + 1)
 
         spy_connect.assert_called_once()
-        mock_redis_connection.set.assert_called_once_with("test-key", expected)
+        mock_redis_connection.set.assert_called_once_with("test-key", expected, ex=None)
+
+    def test_set__ttl(self, cache: Cache, mock_redis_connection, spy_connect):
+        ttl = 5
+
+        cache.set("test-key", 1, ttl=ttl)
+
+        spy_connect.assert_called_once()
+        mock_redis_connection.set.assert_called_once_with("test-key", 1, ex=ttl)
 
     def test_set__unavailable(self, cache: Cache, mock_redis_connection, spy_connect):
         mock_redis_connection.ping.return_value = False
@@ -183,10 +191,10 @@ class TestCache:
 
         spy_connect.assert_called_once()
         mock_redis_connection.set.assert_called_once()
-        # Verify first arg is the key
-        assert mock_redis_connection.set.call_args[0][0] == "test-key"
-        # Verify second arg is bytes (arrow serialized)
-        assert isinstance(mock_redis_connection.set.call_args[0][1], bytes)
+        # verify first arg is the key
+        assert mock_redis_connection.set.call_args.args[0] == "test-key"
+        # verify second arg is bytes (arrow serialized)
+        assert isinstance(mock_redis_connection.set.call_args.args[1], bytes)
 
     def test_set_df__empty_df(self, cache: Cache, mock_redis_connection, spy_connect):
         empty_df = pd.DataFrame()
@@ -194,21 +202,29 @@ class TestCache:
 
         spy_connect.assert_called_once()
         mock_redis_connection.set.assert_called_once()
-        # Verify empty DataFrame is handled
+        # verify empty DataFrame is handled
         assert isinstance(mock_redis_connection.set.call_args[0][1], bytes)
 
     def test_set_df__roundtrip(self, cache: Cache, mock_redis_connection, spy_connect, df, mocker):
-        # Setup mock to return the serialized value on get
-        def mock_set(key, value):
+        # setup mock to return the serialized value on get
+        def mock_set(key, value, ex):
             mock_redis_connection.get.return_value = value
 
         mock_redis_connection.set.side_effect = mock_set
 
-        # Set the DataFrame
+        # set the DataFrame
         cache.set_df("test-key", df)
 
-        # Get it back
+        # get it back
         result = cache.get_df("test-key")
 
         pd.testing.assert_frame_equal(result, df)
         spy_connect.assert_has_calls([mocker.call(), mocker.call()])
+
+    def test_set_df__ttl(self, cache: Cache, mock_redis_connection, df):
+        """Test setting a DataFrame in the cache"""
+        ttl = 5
+        cache.set_df("test-key", df, ttl=ttl)
+
+        # verify ttl argument
+        assert mock_redis_connection.set.call_args.kwargs["ex"] == ttl

--- a/tests/pytest/pems_data/test_init.py
+++ b/tests/pytest/pems_data/test_init.py
@@ -1,0 +1,31 @@
+import pytest
+
+from pems_data import ServiceFactory
+from pems_data.cache import Cache
+from pems_data.services.stations import StationsService
+from pems_data.sources.cache import CachingDataSource
+from pems_data.sources.s3 import S3DataSource
+
+
+class TestServiceFactory:
+
+    @pytest.fixture
+    def factory(self):
+        return ServiceFactory()
+
+    def test_init_cache(self, factory: ServiceFactory):
+        assert isinstance(factory.cache, Cache)
+
+    def test_init_s3_source(self, factory: ServiceFactory):
+        assert isinstance(factory.s3_source, S3DataSource)
+
+    def test_init_caching_s3_source(self, factory: ServiceFactory):
+        assert isinstance(factory.caching_s3_source, CachingDataSource)
+        assert isinstance(factory.caching_s3_source.data_source, S3DataSource)
+        assert isinstance(factory.caching_s3_source.cache, Cache)
+
+    def test_stations_service(self, factory: ServiceFactory):
+        service = factory.stations_service()
+
+        assert isinstance(service, StationsService)
+        assert service.data_source == factory.caching_s3_source

--- a/tests/pytest/pems_data/test_serialization.py
+++ b/tests/pytest/pems_data/test_serialization.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import pyarrow as pa
+import pytest
+
+from pems_data.serialization import arrow_bytes_to_df, df_to_arrow_bytes
+
+
+@pytest.fixture
+def df():
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+
+
+@pytest.fixture
+def arrow_bytes(df):
+    # convert df to actual arrow bytes for testing
+    table = pa.Table.from_pandas(df, preserve_index=False)
+    sink = pa.BufferOutputStream()
+    with pa.ipc.RecordBatchStreamWriter(sink, table.schema) as writer:
+        writer.write_table(table)
+    return sink.getvalue().to_pybytes()
+
+
+def test_arrow_bytes_to_df_with_valid_data(arrow_bytes, df):
+    result = arrow_bytes_to_df(arrow_bytes)
+    pd.testing.assert_frame_equal(result, df)
+
+
+def test_arrow_bytes_to_df_with_none():
+    result = arrow_bytes_to_df(None)
+    pd.testing.assert_frame_equal(result, pd.DataFrame())
+
+
+def test_arrow_bytes_to_df_with_empty_bytes():
+    result = arrow_bytes_to_df(b"")
+    pd.testing.assert_frame_equal(result, pd.DataFrame())
+
+
+def test_df_to_arrow_bytes_serialization(df):
+    result = df_to_arrow_bytes(df)
+
+    # convert back to DataFrame to verify data integrity
+    reconstructed_df = arrow_bytes_to_df(result)
+    pd.testing.assert_frame_equal(reconstructed_df, df)
+
+
+def test_df_to_arrow_bytes_empty_df():
+    empty_df = pd.DataFrame()
+    result = df_to_arrow_bytes(empty_df)
+
+    # verify we can deserialize empty DataFrame
+    reconstructed_df = arrow_bytes_to_df(result)
+    pd.testing.assert_frame_equal(reconstructed_df, empty_df)
+
+
+def test_df_to_arrow_bytes_preserves_dtypes(df):
+    result = df_to_arrow_bytes(df)
+    reconstructed_df = arrow_bytes_to_df(result)
+
+    assert df.dtypes.equals(reconstructed_df.dtypes)

--- a/tests/pytest/pems_data/test_serialization.py
+++ b/tests/pytest/pems_data/test_serialization.py
@@ -6,11 +6,6 @@ from pems_data.serialization import arrow_bytes_to_df, df_to_arrow_bytes
 
 
 @pytest.fixture
-def df():
-    return pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
-
-
-@pytest.fixture
 def arrow_bytes(df):
     # convert df to actual arrow bytes for testing
     table = pa.Table.from_pandas(df, preserve_index=False)


### PR DESCRIPTION
Closes #198 

## What this PR does

_See #196 for docs that describe `pems_data` architecture and usage_

Introduces a caching layer for `pems_data` that is mostly transparent for users/callers of `pems_data` functionality.

The main caching interface is defined in the `pems_data.cache.Cache` class, which is a wrapper around a `redis` connection.

`redis` is added as a local Compose service, and the `pems-cache` CLI is added to help debug and inspect the cache.

### `pems_data.cache.Cache` class

* Establishes and manages a connection to `redis`
* Defines `get` and `set` wrappers
* Helpers to `get`/`set` DataFrames from the cache

### `pems_data.sources.cache.CachingDataSource` class

An `IDataSource` implementation (see #187) that wraps _another_ `IDataSource` and calls out to the cache first before performing any needed `.read()` operations on the underlying data source. Data returned from `.read()` is cached before returning.

### `pems_data.ServiceFactory` class

With the introduction of the caching layer, the services (e.g. `StationsService`) need additional wiring and setup. This class wraps that setup so callers can get a service that is ready to use. This class should usually serve as the main entrypoint into `pems_data` for callers.