### PR TITLE
Full-width design spike

### DIFF
--- a/pems_web/src/pems_web/core/templates/core/base.html
+++ b/pems_web/src/pems_web/core/templates/core/base.html
@@ -115,7 +115,7 @@
     <div id="main-content" class="main-content">
       <div class="container-fluid">
         <main class="main-primary">
-          <h1>
+          <h1 class="m-y-md">
             {% block headline %}
             {% endblock headline %}
           </h1>

--- a/pems_web/src/pems_web/core/templates/core/base.html
+++ b/pems_web/src/pems_web/core/templates/core/base.html
@@ -54,7 +54,7 @@
       </div>
       <!-- header branding with light gray background -->
       <div class="section-default">
-        <div class="branding">
+        <div class="branding container-fluid">
           <div class="header-organization-banner">
             <a href="{% url 'core:index' %}">
               <div class="logo-assets">
@@ -94,7 +94,7 @@
             </a>
           </div>
         </div>
-        <nav id="navigation" class="main-navigation singlelevel" aria-label="Main navigation">
+        <nav id="navigation" class="main-navigation container-fluid singlelevel" aria-label="Main navigation">
           <ul id="nav_list" class="top-level-nav">
             <li class="nav-item">
               <a href="{% url 'core:index' %}" class="first-level-link">Home</a>

--- a/pems_web/src/pems_web/core/templates/core/base.html
+++ b/pems_web/src/pems_web/core/templates/core/base.html
@@ -32,7 +32,7 @@
     <header role="banner" id="header" class="global-header fixed">
       <!-- Utility header structural component -->
       <div class="utility-header">
-        <div class="container">
+        <div class="container-fluid">
           <div class="flex-row">
             <div class="social-media-links">
               <div class="header-cagov-logo">
@@ -84,7 +84,7 @@
         </div>
       </div>
       <!-- Top Level Navigation Only -->
-      <div class="navigation-search full-width-nav container">
+      <div class="navigation-search full-width-nav container-fluid">
         <div id="head-search" class="search-container featured-search">
           <div class="d-block d-lg-none">
             <a href="{% url 'core:index' %}" class="drawer-logo-link first-level-link">
@@ -113,7 +113,7 @@
       </div>
     </header>
     <div id="main-content" class="main-content">
-      <div class="container">
+      <div class="container-fluid">
         <main class="main-primary">
           <h1>
             {% block headline %}
@@ -126,7 +126,7 @@
     </div>
     <!-- Global Footer -->
     <footer id="footer" class="global-footer">
-      <div class="container">
+      <div class="container-fluid">
         <div class="d-flex">
           <a href="https://www.ca.gov" class="cagov-logo">
             <span class="sr-only">CA.gov</span>
@@ -152,7 +152,7 @@
       </div>
       <!-- Copyright Statement -->
       <div class="copyright">
-        <div class="container text-right">
+        <div class="container-fluid text-right">
           <span aria-hidden="true">©</span>
           <span id="thisyear">
             <script>document.getElementById('thisyear').appendChild(document.createTextNode(new Date().getFullYear()))</script>

--- a/pems_web/src/pems_web/districts/templates/districts/index.html
+++ b/pems_web/src/pems_web/districts/templates/districts/index.html
@@ -5,7 +5,7 @@
 {% endblock headline %}
 
 {% block inner-content %}
-    <div class="container-fluid p-t-lg">
+    <div class="container-fluid p-t-xs">
         <div class="row">
             <div class="col-lg-2 pb-lg-5" role="complementary">
                 {% block sidebar %}

--- a/pems_web/src/pems_web/districts/templates/districts/index.html
+++ b/pems_web/src/pems_web/districts/templates/districts/index.html
@@ -5,7 +5,7 @@
 {% endblock headline %}
 
 {% block inner-content %}
-    <div class="container p-t-lg">
+    <div class="container-fluid p-t-lg">
         <div class="row">
             <div class="col-lg-2 pb-lg-5" role="complementary">
                 {% block sidebar %}

--- a/pems_web/src/pems_web/static/css/styles.css
+++ b/pems_web/src/pems_web/static/css/styles.css
@@ -10,3 +10,8 @@ header {
     }
   }
 }
+
+.main-navigation.container-fluid,
+.branding.container-fluid {
+  max-width: 100% !important;
+}


### PR DESCRIPTION
The aim of this PR spike is to see how easy or hard it is to convert the CA State Web Template design usage here on PeMS to a full-width design, that is more aligned with what a data-heavy dashboard site's layout and usage.

Just by adding 1 style declaration and changing the `container` class to `container-fluid` (a Bootstrap helper class), we can widen the area for the visualizations and give the user a lot more real estate:

<img width="1512" height="865" alt="image" src="https://github.com/user-attachments/assets/63c176a0-8b95-466d-a3e6-fd9bce7c2217" />

For context, the Django admin by default is also a full-width app:
<img width="1512" height="899" alt="image" src="https://github.com/user-attachments/assets/999cc856-2f6c-4046-b272-5f7288099aad" />
<img width="1512" height="330" alt="image" src="https://github.com/user-attachments/assets/2afc5332-2d58-4681-8538-147c4a205e88" />


## Outstanding questions
- Why does the side nav have a dynamically-generated max-height? It should not scroll.