### PR TITLE
Fix: use mkdocs gh-deploy directly

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -97,12 +97,10 @@ jobs:
             "**/pyproject.toml"
             "docs/requirements.txt"
 
-      - name: Install local pacakges
+      - name: Install MkDocs requirements
         run: |
-          pip install ./pems_data
+          pip install ./pems_data -r docs/requirements.txt
 
-      - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@master
-        env:
-          REQUIREMENTS: docs/requirements.txt
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Deploy MkDocs website
+        run: |
+          mkdocs gh-deploy --force


### PR DESCRIPTION
We need to install `pems_data` before `mkdocs` can build, since we autogenerate some of the docs from the Python docstrings (#196).

The [`mhausenblas/mkdocs-deploy-gh-pages`](https://github.com/mhausenblas/mkdocs-deploy-gh-pages) action step seems to either ignore or not see that installation.

So make the actual deploy work more like the preview deploy, just install dependencies and use [`mkdocs gh-deploy`](https://www.mkdocs.org/user-guide/deploying-your-docs/#project-pages) directly (which also builds the site).